### PR TITLE
[FEAT] 프로모션 도메인 모델 설계

### DIFF
--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -1,0 +1,16 @@
+language: 'ko-KR'
+early_access: false
+reviews:
+  profile: 'chill'
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"
+chat:
+  auto_reply: true

--- a/src/main/java/org/nextme/promotion_service/participation/domain/ParticipationStatus.java
+++ b/src/main/java/org/nextme/promotion_service/participation/domain/ParticipationStatus.java
@@ -1,0 +1,7 @@
+package org.nextme.promotion_service.participation.domain;
+
+public enum ParticipationStatus {
+	QUEUED,	// 대기열 진입
+	WON, 	// 당첨
+	LOST	// 탈락
+}

--- a/src/main/java/org/nextme/promotion_service/participation/domain/ParticipationStatus.java
+++ b/src/main/java/org/nextme/promotion_service/participation/domain/ParticipationStatus.java
@@ -1,7 +1,6 @@
 package org.nextme.promotion_service.participation.domain;
 
 public enum ParticipationStatus {
-	QUEUED,	// 대기열 진입
 	WON, 	// 당첨
 	LOST	// 탈락
 }

--- a/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
+++ b/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
@@ -4,14 +4,18 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.nextme.common.jpa.BaseEntity;
+import org.nextme.promotion_service.promotion.domain.Promotion;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,9 +31,10 @@ public class PromotionParticipation extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 
-	// 참여한 프로모션 ID
-	@Column(nullable = false)
-	private UUID promotionId;
+	// 참여한 프로모션
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "promotion_id", nullable = false)
+	private Promotion promotion;
 
 	// 참여한 사용자 ID
 	@Column(nullable = false)
@@ -63,13 +68,13 @@ public class PromotionParticipation extends BaseEntity {
 
 	// 당첨자 생성
 	public static PromotionParticipation createWinner(
-		UUID promotionId,
+		Promotion promotion,
 		Long userId,
 		String ipAddress,
 		Long position
 	) {
 		PromotionParticipation participation = new PromotionParticipation();
-		participation.promotionId = promotionId;
+		participation.promotion = promotion;
 		participation.userId = userId;
 		participation.ipAddress = ipAddress;
 		participation.participatedAt = LocalDateTime.now();
@@ -80,12 +85,12 @@ public class PromotionParticipation extends BaseEntity {
 
 	// 탈락자 생성
 	public static PromotionParticipation createLoser(
-		UUID promotionId,
+		Promotion promotion,
 		Long userId,
 		String ipAddress
 	) {
 		PromotionParticipation participation = new PromotionParticipation();
-		participation.promotionId = promotionId;
+		participation.promotion = promotion;
 		participation.userId = userId;
 		participation.ipAddress = ipAddress;
 		participation.participatedAt = LocalDateTime.now();

--- a/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
+++ b/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
@@ -1,0 +1,95 @@
+package org.nextme.promotion_service.participation.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.nextme.common.jpa.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_promotion_participation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PromotionParticipation extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	// 참여한 프로모션 ID
+	@Column(nullable = false)
+	private UUID promotionId;
+
+	// 참여한 사용자 ID
+	@Column(nullable = false)
+	private Long userId;
+
+	// 참여 시각
+	@Column(nullable = false)
+	private LocalDateTime participatedAt;
+
+	// 대기열 순번 (당첨 시 몇 번째로 당첨되었는지)
+	@Column
+	private Long queuePosition;
+
+	// 참여 상태
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ParticipationStatus status;
+
+	// 참여 시점의 사용자 IP 주소
+	@Column(length = 45)
+	private String ipAddress;
+
+	// 참여 시점의 User-Agent
+	@Column(length = 500)
+	private String userAgent;
+
+	// 당첨 여부 확인
+	public boolean isWinner() {
+		return this.status == ParticipationStatus.WON;
+	}
+
+	// 당첨자 생성
+	public static PromotionParticipation createWinner(
+		UUID promotionId,
+		Long userId,
+		String ipAddress,
+		Long position
+	) {
+		PromotionParticipation participation = new PromotionParticipation();
+		participation.promotionId = promotionId;
+		participation.userId = userId;
+		participation.ipAddress = ipAddress;
+		participation.participatedAt = LocalDateTime.now();
+		participation.status = ParticipationStatus.WON;
+		participation.queuePosition = position;
+		return participation;
+	}
+
+	// 탈락자 생성
+	public static PromotionParticipation createLoser(
+		UUID promotionId,
+		Long userId,
+		String ipAddress
+	) {
+		PromotionParticipation participation = new PromotionParticipation();
+		participation.promotionId = promotionId;
+		participation.userId = userId;
+		participation.ipAddress = ipAddress;
+		participation.participatedAt = LocalDateTime.now();
+		participation.status = ParticipationStatus.LOST;
+		return participation;
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
+++ b/src/main/java/org/nextme/promotion_service/participation/domain/PromotionParticipation.java
@@ -71,12 +71,14 @@ public class PromotionParticipation extends BaseEntity {
 		Promotion promotion,
 		Long userId,
 		String ipAddress,
+		String userAgent,
 		Long position
 	) {
 		PromotionParticipation participation = new PromotionParticipation();
 		participation.promotion = promotion;
 		participation.userId = userId;
 		participation.ipAddress = ipAddress;
+		participation.userAgent = userAgent;
 		participation.participatedAt = LocalDateTime.now();
 		participation.status = ParticipationStatus.WON;
 		participation.queuePosition = position;
@@ -87,12 +89,14 @@ public class PromotionParticipation extends BaseEntity {
 	public static PromotionParticipation createLoser(
 		Promotion promotion,
 		Long userId,
-		String ipAddress
+		String ipAddress,
+		String userAgent
 	) {
 		PromotionParticipation participation = new PromotionParticipation();
 		participation.promotion = promotion;
 		participation.userId = userId;
 		participation.ipAddress = ipAddress;
+		participation.userAgent = userAgent;
 		participation.participatedAt = LocalDateTime.now();
 		participation.status = ParticipationStatus.LOST;
 		return participation;

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
@@ -1,0 +1,77 @@
+package org.nextme.promotion_service.promotion.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.nextme.common.jpa.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "promotions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Promotion extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	// 프로모션 이름
+	@Column(nullable = false)
+	private String name;
+
+	// 프로모션 시작 시간
+	@Column(nullable = false)
+	private LocalDateTime startTime;
+
+	// 프로모션 종료 시간
+	@Column(nullable = false)
+	private LocalDateTime endTime;
+
+	// 선착순 당첨 인원
+	@Column(nullable = false)
+	private Integer totalStock;
+
+	// 지급할 포인트 금액
+	@Column(nullable = false)
+	private Integer pointAmount;
+
+	// 프로모션 상태
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private PromotionStatus status;
+
+	// 현재 프로모션이 진행 중인지 확인
+	public boolean isActive() {
+		LocalDateTime now = LocalDateTime.now();
+		return status == PromotionStatus.ACTIVE
+			&& now.isAfter(startTime)
+			&& now.isBefore(endTime);
+	}
+
+	// 참여 가능한 상태인지 검증
+	public boolean canParticipate() {
+		return isActive() && totalStock > 0;
+	}
+
+	// 프로모션 시작 처리
+	public void start() {
+		this.status = PromotionStatus.ACTIVE;
+	}
+
+	// 프로모션 종료 처리
+	public void end() {
+		this.status = PromotionStatus.ENDED;
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "promotions")
+@Table(name = "p_promotion_participation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Promotion extends BaseEntity {

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "p_promotion_participation")
+@Table(name = "p_promotion")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Promotion extends BaseEntity {

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/PromotionStatus.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/PromotionStatus.java
@@ -1,7 +1,7 @@
 package org.nextme.promotion_service.promotion.domain;
 
 public enum PromotionStatus {
-	SCHEDULES,	// 예정
+	SCHEDULED,	// 예정
 	ACTIVE, 	// 진행중
 	ENDED		// 완료
 }

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/PromotionStatus.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/PromotionStatus.java
@@ -1,0 +1,7 @@
+package org.nextme.promotion_service.promotion.domain;
+
+public enum PromotionStatus {
+	SCHEDULES,	// 예정
+	ACTIVE, 	// 진행중
+	ENDED		// 완료
+}


### PR DESCRIPTION
## 📝 요약 (Summary)
선착순 프로모션 시스템의 핵심 도메인 모델을 구현했습니다.


## 🛠️ 작업 내용 (Details)

  1. 도메인 Enum 추가

  - PromotionStatus: 프로모션 상태 관리 (SCHEDULED, ACTIVE, ENDED)
  - ParticipationStatus: 참여 결과 상태 (WON, LOST)

  2. Promotion 엔티티

  - 선착순 프로모션 정보 관리
  - 주요 필드: name, startTime, endTime, totalStock, pointAmount
  - 비즈니스 로직: isActive(), canParticipate(), start(), end()
  - UUID 기반 ID 사용

  3. PromotionParticipation 엔티티

  - 사용자의 프로모션 참여 기록 관리
  - 주요 필드: promotionId, userId, participatedAt, queuePosition, status, ipAddress,
  userAgent
  - 정적 팩토리 메서드: createWinner(), createLoser()
  - 어뷰징 방지를 위한 IP/User-Agent 저장

  4. 설계 원칙
  - DDD 패키지 구조: promotion, participation 도메인 분리
  - BaseEntity 상속: msa-common 모듈의 JPA Audit 활용
  - 불변성: 정적 팩토리 메서드로 생성 시점에 상태 확정
  - 도메인 로직 캡슐화: 비즈니스 규칙을 엔티티 내부에 구현



## 🔀 변경 유형 (Change Type)


- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)

## 🧪 테스트 방법 (Testing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added promotion lifecycle management (scheduled, active, ended) with start/end controls and availability checks
  * Introduced promotion participation tracking with winner/loser distinctions and participation metadata

* **Chores**
  * Added configuration file with language, review, and chat automation settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->