### PR TITLE
[FEAT] Redis 기반 선착순 프로모션 대기열 시스템 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ reviews:
   profile: 'chill'
   request_changes_workflow: false
   high_level_summary: true
-  poem: false
+  poem: true
   review_status: true
   collapse_walkthrough: false
   auto_review:

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	implementation 'com.github.sparta-next-me:msa-common:v0.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Actuator & Prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.github.sparta-next-me:msa-common:v0.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
+++ b/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
@@ -2,12 +2,17 @@ package org.nextme.promotion_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableJpaAuditing
+@ComponentScan(basePackages = {
+	"org.nextme.promotion_service",
+	"org.nextme.infrastructure"
+})
 public class PromotionServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
+++ b/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
@@ -2,8 +2,10 @@ package org.nextme.promotion_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PromotionServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
+++ b/src/main/java/org/nextme/promotion_service/PromotionServiceApplication.java
@@ -2,10 +2,12 @@ package org.nextme.promotion_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class PromotionServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/nextme/promotion_service/global/config/RedisConfig.java
+++ b/src/main/java/org/nextme/promotion_service/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package org.nextme.promotion_service.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// Key는 String으로 직렬화
+		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		template.setKeySerializer(stringSerializer);
+		template.setHashKeySerializer(stringSerializer);
+
+		// Value는 JSON으로 직렬화
+		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
+		template.setValueSerializer(jsonSerializer);
+		template.setHashValueSerializer(jsonSerializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/nextme/promotion_service/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.nextme.promotion_service.global.exception;
+
+import org.nextme.infrastructure.exception.ErrorCode;
+import org.nextme.infrastructure.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse<Void>> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException e) {
+		log.warn("HttpMessageNotReadableException: {}", e.getMessage());
+
+		ErrorCode errorCode = ErrorCode.REQUEST_VALIDATION_ERROR;
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(new ErrorResponse<>(errorCode.getCode(), "요청 본문이 누락되었거나 형식이 올바르지 않습니다.", null));
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/global/exception/PromotionErrorCode.java
+++ b/src/main/java/org/nextme/promotion_service/global/exception/PromotionErrorCode.java
@@ -1,0 +1,33 @@
+package org.nextme.promotion_service.global.exception;
+
+import org.nextme.infrastructure.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PromotionErrorCode {
+
+	// 프로모션 관련
+	PROMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROMOTION_NOT_FOUND", "존재하지 않는 프로모션입니다"),
+	PROMOTION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "PROMOTION_NOT_AVAILABLE", "참여 가능한 프로모션이 아닙니다."),
+	PROMOTION_ALREADY_JOINED(HttpStatus.CONFLICT, "PROMOTION_ALREADY_JOINED", "이미 참여하셨습니다"),
+	PROMOTION_QUEUE_FULL(HttpStatus.TOO_MANY_REQUESTS, "PROMOTION_QUEUE_FULL", "대기 인원이 초과되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String defaultMessage;
+
+	// ApplicationException 생성 헬퍼
+	public ApplicationException toException() {
+		return new ApplicationException(this.httpStatus, this.code, this.defaultMessage);
+	}
+
+	// 커스텀 메시지로 ApplicationException 발생
+	public ApplicationException toException(String customMessage) {
+		return new ApplicationException(this.httpStatus, this.code, customMessage);
+	}
+
+}

--- a/src/main/java/org/nextme/promotion_service/global/exception/PromotionErrorCode.java
+++ b/src/main/java/org/nextme/promotion_service/global/exception/PromotionErrorCode.java
@@ -14,7 +14,10 @@ public enum PromotionErrorCode {
 	PROMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROMOTION_NOT_FOUND", "존재하지 않는 프로모션입니다"),
 	PROMOTION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "PROMOTION_NOT_AVAILABLE", "참여 가능한 프로모션이 아닙니다."),
 	PROMOTION_ALREADY_JOINED(HttpStatus.CONFLICT, "PROMOTION_ALREADY_JOINED", "이미 참여하셨습니다"),
-	PROMOTION_QUEUE_FULL(HttpStatus.TOO_MANY_REQUESTS, "PROMOTION_QUEUE_FULL", "대기 인원이 초과되었습니다.");
+	PROMOTION_QUEUE_FULL(HttpStatus.TOO_MANY_REQUESTS, "PROMOTION_QUEUE_FULL", "대기 인원이 초과되었습니다."),
+
+	// 참여 관련
+	PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTICIPATION_NOT_FOUND", "참여 기록을 찾을 수 없습니다");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/org/nextme/promotion_service/participation/application/ParticipationQueryService.java
+++ b/src/main/java/org/nextme/promotion_service/participation/application/ParticipationQueryService.java
@@ -1,0 +1,63 @@
+package org.nextme.promotion_service.participation.application;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.nextme.promotion_service.global.exception.PromotionErrorCode;
+import org.nextme.promotion_service.participation.domain.ParticipationStatus;
+import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+import org.nextme.promotion_service.participation.infrastructure.persistence.PromotionParticipationRepository;
+import org.nextme.promotion_service.participation.presentation.dto.ParticipationResultResponse;
+import org.nextme.promotion_service.participation.presentation.dto.WinnerListResponse;
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.infrastructure.persistence.PromotionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ParticipationQueryService {
+
+	private final PromotionRepository promotionRepository;
+	private final PromotionParticipationRepository participationRepository;
+
+	/*
+	특정 사용자의 참여 결과 조회
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	@return 참여 결과
+	 */
+	@Transactional(readOnly = true)
+	public ParticipationResultResponse getParticipationResult(UUID promotionId, Long userId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		PromotionParticipation participation = participationRepository
+			.findByPromotionAndUserId(promotion, userId)
+			.orElseThrow(PromotionErrorCode.PARTICIPATION_NOT_FOUND::toException);
+
+		return ParticipationResultResponse.from(participation);
+	}
+
+	/*
+	당첨자 목록 조회
+	@param promotionId 프로모션 ID
+	@return 당첨자 목록
+	 */
+	@Transactional(readOnly = true)
+	public List<WinnerListResponse> getWinners(UUID promotionId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		List<PromotionParticipation> winners = participationRepository
+			.findByPromotionAndStatusOrderByQueuePositionAsc(promotion, ParticipationStatus.WON);
+
+		return winners.stream()
+			.map(WinnerListResponse::from)
+			.toList();
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/participation/infrastructure/persistence/PromotionParticipationRepository.java
+++ b/src/main/java/org/nextme/promotion_service/participation/infrastructure/persistence/PromotionParticipationRepository.java
@@ -1,9 +1,20 @@
 package org.nextme.promotion_service.participation.infrastructure.persistence;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import org.nextme.promotion_service.participation.domain.ParticipationStatus;
 import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+import org.nextme.promotion_service.promotion.domain.Promotion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PromotionParticipationRepository extends JpaRepository<PromotionParticipation, UUID> {
+
+	// 특정 프로모션의 특정 사용자 참여 기록 조회
+	Optional<PromotionParticipation> findByPromotionAndUserId(Promotion promotion, Long userId);
+
+	// 특정 프로모션의 당첨자 목록 조회 (순번 순)
+	List<PromotionParticipation> findByPromotionAndStatusOrderByQueuePositionAsc(
+		Promotion promotion, ParticipationStatus status);
 }

--- a/src/main/java/org/nextme/promotion_service/participation/infrastructure/persistence/PromotionParticipationRepository.java
+++ b/src/main/java/org/nextme/promotion_service/participation/infrastructure/persistence/PromotionParticipationRepository.java
@@ -1,0 +1,9 @@
+package org.nextme.promotion_service.participation.infrastructure.persistence;
+
+import java.util.UUID;
+
+import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PromotionParticipationRepository extends JpaRepository<PromotionParticipation, UUID> {
+}

--- a/src/main/java/org/nextme/promotion_service/participation/presentation/ParticipationController.java
+++ b/src/main/java/org/nextme/promotion_service/participation/presentation/ParticipationController.java
@@ -1,0 +1,54 @@
+package org.nextme.promotion_service.participation.presentation;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.nextme.infrastructure.success.CustomResponse;
+import org.nextme.promotion_service.participation.application.ParticipationQueryService;
+import org.nextme.promotion_service.participation.presentation.dto.ParticipationResultResponse;
+import org.nextme.promotion_service.participation.presentation.dto.WinnerListResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/promotions")
+@RequiredArgsConstructor
+public class ParticipationController {
+
+	private final ParticipationQueryService participationQueryService;
+
+	/*
+	특정 사용자의 참여 결과 조회 API
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	@return 참여 결과
+	 */
+	@GetMapping("/{promotionId}/participations/{userId}")
+	public ResponseEntity<CustomResponse<ParticipationResultResponse>> getParticipationResult(
+		@PathVariable UUID promotionId,
+		@PathVariable Long userId
+	) {
+		ParticipationResultResponse response = participationQueryService.getParticipationResult(promotionId, userId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+
+	/*
+	당첨자 목록 조회 API
+	@param promotionId 프로모션 ID
+	@return 당첨자 목록
+	 */
+	@GetMapping("/{promotionId}/winners")
+	public ResponseEntity<CustomResponse<List<WinnerListResponse>>> getWinners(
+		@PathVariable UUID promotionId
+	) {
+		List<WinnerListResponse> response = participationQueryService.getWinners(promotionId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/participation/presentation/dto/ParticipationResultResponse.java
+++ b/src/main/java/org/nextme/promotion_service/participation/presentation/dto/ParticipationResultResponse.java
@@ -1,0 +1,36 @@
+package org.nextme.promotion_service.participation.presentation.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.nextme.promotion_service.participation.domain.ParticipationStatus;
+import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+
+// 참여 결과 응답 DTO
+public record ParticipationResultResponse(
+	UUID participationId,
+	UUID promotionId,
+	String promotionName,
+	Long userId,
+	ParticipationStatus status,
+	Long queuePosition,      // 당첨 순번 (당첨자만)
+	LocalDateTime participatedAt,
+	String message
+) {
+	public static ParticipationResultResponse from(PromotionParticipation participation) {
+		String message = participation.getStatus() == ParticipationStatus.WON
+			? String.format("축하합니다! %d번째 당첨자입니다.", participation.getQueuePosition())
+			: "아쉽게도 당첨되지 않았습니다.";
+
+		return new ParticipationResultResponse(
+			participation.getId(),
+			participation.getPromotion().getId(),
+			participation.getPromotion().getName(),
+			participation.getUserId(),
+			participation.getStatus(),
+			participation.getQueuePosition(),
+			participation.getParticipatedAt(),
+			message
+		);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/participation/presentation/dto/WinnerListResponse.java
+++ b/src/main/java/org/nextme/promotion_service/participation/presentation/dto/WinnerListResponse.java
@@ -1,0 +1,20 @@
+package org.nextme.promotion_service.participation.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+
+// 당첨자 목록 응답 DTO
+public record WinnerListResponse(
+	Long userId,
+	Long queuePosition,
+	LocalDateTime participatedAt
+) {
+	public static WinnerListResponse from(PromotionParticipation participation) {
+		return new WinnerListResponse(
+			participation.getUserId(),
+			participation.getQueuePosition(),
+			participation.getParticipatedAt()
+		);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/application/PromotionParticipationService.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/application/PromotionParticipationService.java
@@ -38,9 +38,9 @@ public class PromotionParticipationService {
 
 		// 클라이언트 IP 추출
 		String ipAddress = getClientIp(httpRequest);
+		String userAgent = httpRequest.getHeader("User-Agent");
 
 		log.info("프로모션 참여 요청 - promotionId: {}, userId: {}, ip: {}", promotionId, userId, ipAddress);
-
 
 		// 1. 프로모션 조회
 		Promotion promotion = promotionRepository.findById(promotionId)
@@ -68,7 +68,7 @@ public class PromotionParticipationService {
 		}
 
 		// 5. 대기열 등록
-		String queueData = String.format("%d:%s:%s", userId, ipAddress, LocalDateTime.now());
+		String queueData = String.format("%d:%s:%s:%s", userId, ipAddress, userAgent, LocalDateTime.now());
 		queueService.enqueue(promotionId, queueData);
 
 		// 6. 성공 응답

--- a/src/main/java/org/nextme/promotion_service/promotion/application/PromotionParticipationService.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/application/PromotionParticipationService.java
@@ -1,0 +1,71 @@
+package org.nextme.promotion_service.promotion.application;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.nextme.promotion_service.global.exception.PromotionErrorCode;
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.infrastructure.persistence.PromotionRepository;
+import org.nextme.promotion_service.promotion.infrastructure.redis.PromotionQueueService;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionJoinResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PromotionParticipationService {
+
+	private final PromotionRepository promotionRepository;
+	private final PromotionQueueService queueService;
+
+	// 대기열 최대 크기 = 선착순 인원 * 5
+	private static final int QUEUE_SIZE_MULTIPLIER = 5;
+
+	/*
+	프로모션 참여 처리
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	@param ipAddress 사용자 IP 주소
+	@return 참여 결과
+	 */
+	@Transactional(readOnly = true)
+	public PromotionJoinResponse joinPromotion(UUID promotionId, Long userId, String ipAddress) {
+		// 1. 프로모션 조회
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		// 2. 프로모션 참여 가능 여부 확인
+		if (!promotion.canParticipate()) {
+			throw PromotionErrorCode.PROMOTION_NOT_AVAILABLE.toException();
+		}
+
+		// 3. 중복 체크 + 참여 기록
+		boolean isNewParticipant = queueService.addToJoinedSet(promotionId, userId);
+		if (!isNewParticipant) {
+			throw PromotionErrorCode.PROMOTION_ALREADY_JOINED.toException();
+		}
+
+		// 4. 대기열 크기 확인
+		Long queueSize = queueService.getQueueSize(promotionId);
+		int maxQueueSize = promotion.getTotalStock() * QUEUE_SIZE_MULTIPLIER;
+
+		if (queueSize > maxQueueSize) {
+			// 대기열 초과 시 롤백
+			queueService.removeFromJoinedSet(promotionId, userId);
+			throw PromotionErrorCode.PROMOTION_QUEUE_FULL.toException();
+		}
+
+		// 5. 대기열 등록
+		String queueData = String.format("%d:%s:%s", userId, ipAddress, LocalDateTime.now());
+		queueService.enqueue(promotionId, queueData);
+
+		// 6. 성공 응답
+		Long position = queueSize + 1;
+		log.info("프로모션 참여 성공 - promotionId: {}, userId: {}, position: {}", promotionId, userId, position);
+		return PromotionJoinResponse.success("대기열에 진입했습니다.", position);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/application/PromotionService.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/application/PromotionService.java
@@ -1,0 +1,116 @@
+package org.nextme.promotion_service.promotion.application;
+
+import java.util.UUID;
+
+import org.nextme.promotion_service.global.exception.PromotionErrorCode;
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.domain.PromotionStatus;
+import org.nextme.promotion_service.promotion.infrastructure.persistence.PromotionRepository;
+import org.nextme.promotion_service.promotion.infrastructure.redis.PromotionQueueService;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionCreateRequest;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionResponse;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionStatusResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PromotionService {
+
+	private final PromotionRepository promotionRepository;
+	private final PromotionQueueService queueService;
+
+	/*
+	프로모션 생성
+	@param request 프로모션 생성 요청
+	@return 생성된 프로모션 정보
+	 */
+	@Transactional
+	public PromotionResponse createPromotion(PromotionCreateRequest request) {
+		Promotion promotion = Promotion.builder()
+			.name(request.name())
+			.startTime(request.startTime())
+			.endTime(request.endTime())
+			.totalStock(request.totalStock())
+			.pointAmount(request.pointAmount())
+			.status(PromotionStatus.SCHEDULED)
+			.build();
+
+		Promotion saved = promotionRepository.save(promotion);
+		log.info("프로모션 생성 완료 - id: {}, name: {}", saved.getId(), saved.getName());
+
+		return PromotionResponse.from(saved);
+	}
+
+	/*
+	프로모션 조회
+	@param promotionId 프로모션 ID
+	@return 프로모션 정보
+	 */
+	@Transactional(readOnly = true)
+	public PromotionResponse getPromotion(UUID promotionId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		return PromotionResponse.from(promotion);
+	}
+
+	/*
+	프로모션 시작
+	@param promotionId 프로모션 ID
+	@return 시작된 프로모션 정보
+	 */
+	@Transactional
+	public PromotionResponse startPromotion(UUID promotionId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		promotion.start();
+		log.info("프로모션 시작 - id: {}, name: {}", promotion.getId(), promotion.getName());
+
+		return PromotionResponse.from(promotion);
+	}
+
+	/*
+	프로모션 종료
+	@param promotionId 프로모션 ID
+	@return 종료된 프로모션 정보
+	 */
+	@Transactional
+	public PromotionResponse endPromotion(UUID promotionId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		promotion.end();
+		log.info("프로모션 종료 - id: {}, name: {}", promotion.getId(), promotion.getName());
+
+		return PromotionResponse.from(promotion);
+	}
+
+	/*
+	프로모션 참여 현황 조회
+	@param promotionId 프로모션 ID
+	@return 참여 현황 정보
+	 */
+	@Transactional(readOnly = true)
+	public PromotionStatusResponse getPromotionStatus(UUID promotionId) {
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElseThrow(PromotionErrorCode.PROMOTION_NOT_FOUND::toException);
+
+		// Redis에서 현황 조회
+		Long queueSize = queueService.getQueueSize(promotionId);
+		Long participantCount = queueService.getParticipantCount(promotionId);
+		Long winnerCount = queueService.getWinnerCount(promotionId);
+
+		return PromotionStatusResponse.of(
+			queueSize,
+			participantCount,
+			winnerCount,
+			promotion.getTotalStock()
+		);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/application/PromotionWorker.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/application/PromotionWorker.java
@@ -1,0 +1,99 @@
+package org.nextme.promotion_service.promotion.application;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.nextme.promotion_service.participation.domain.PromotionParticipation;
+import org.nextme.promotion_service.participation.infrastructure.persistence.PromotionParticipationRepository;
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.infrastructure.persistence.PromotionRepository;
+import org.nextme.promotion_service.promotion.infrastructure.redis.PromotionQueueService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/*
+프로모션 대기열 처리 워커
+주기적으로 Redis 대기열에서 데이터를 꺼내 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PromotionWorker {
+
+	private final PromotionQueueService queueService;
+	private final PromotionRepository promotionRepository;
+	private final PromotionParticipationRepository participationRepository;
+
+	// 배치 크기
+	private static final int BATCH_SIZE = 100;
+
+	// 대기열 처리 스케줄러
+	@Scheduled(fixedRate = 1000)
+	@Transactional
+	public void processQueue() {
+		// 임시 특정 프로모션 처리
+		log.debug("워커 실행 - 대기열 처리 시작");
+	}
+
+	public void processPromotionQueue(UUID promotionId) {
+		// 1. 프로모션 조회
+		Promotion promotion = promotionRepository.findById(promotionId)
+			.orElse(null);
+
+		if (promotion == null) {
+			log.warn("프로모션을 찾을 수 없음 - promotionId: {}", promotionId);
+			return;
+		}
+
+		// 2. 배치 처리
+		List<PromotionParticipation> batch = new ArrayList<>();
+
+		for (int i = 0; i < BATCH_SIZE; i++) {
+			// 큐에서 데이터 꺼내기
+			String queueData = queueService.dequeue(promotionId);
+
+			if (queueData == null) {
+				break; // 큐가 비었으면 종료
+			}
+
+			// 데이터 파싱 : "userId:ipAddress:timestamp"
+			String[] parts = queueData.split(":");
+			if (parts.length < 3) {
+				log.warn("잘못된 큐 데이터 형식 - data: {}", queueData);
+				continue;
+			}
+
+			Long userId = Long.parseLong(parts[0]);
+			String ipAddress = parts[1];
+			String userAgent = parts[2];
+
+			// 선착순 판단 (원자적 증가)
+			Long winnerCount = queueService.incrementWinnerCount(promotionId);
+
+			// 당첨/탈락 결정
+			PromotionParticipation participation;
+			if (winnerCount <= promotion.getTotalStock()) {
+				// 당첨
+				participation = PromotionParticipation.createWinner(promotion, userId, ipAddress, userAgent, winnerCount);
+				log.info("당첨 - promotionId: {}, userId: {}, position: {}", promotionId, userId, winnerCount);
+			} else {
+				// 탈락
+				participation = PromotionParticipation.createLoser(promotion, userId, ipAddress, userAgent);
+				log.info("탈락 - promotionId: {}, userId: {}", promotionId, userId);
+			}
+
+			batch.add(participation); // 배치에 추가
+		}
+
+		// 3. 배치 저장
+		if (!batch.isEmpty()) {
+			participationRepository.saveAll(batch);
+			log.info("배치 저장 완료 - promotionId: {}, count: {}", promotionId, batch.size());
+		}
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/application/PromotionWorker.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/application/PromotionWorker.java
@@ -36,8 +36,9 @@ public class PromotionWorker {
 	@Scheduled(fixedRate = 1000)
 	@Transactional
 	public void processQueue() {
-		// 임시 특정 프로모션 처리
-		log.debug("워커 실행 - 대기열 처리 시작");
+		// 임시: 테스트용 프로모션 ID 하드코딩
+		UUID testPromotionId = UUID.fromString("e503dfc2-a7cd-473a-b661-d32da707e1ef");
+		processPromotionQueue(testPromotionId);
 	}
 
 	public void processPromotionQueue(UUID promotionId) {

--- a/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/domain/Promotion.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -51,6 +52,17 @@ public class Promotion extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private PromotionStatus status;
+
+	@Builder
+	public Promotion(String name, LocalDateTime startTime, LocalDateTime endTime,
+		Integer totalStock, Integer pointAmount, PromotionStatus status) {
+		this.name = name;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.totalStock = totalStock;
+		this.pointAmount = pointAmount;
+		this.status = status != null ? status : PromotionStatus.SCHEDULED;
+	}
 
 	// 현재 프로모션이 진행 중인지 확인
 	public boolean isActive() {

--- a/src/main/java/org/nextme/promotion_service/promotion/infrastructure/persistence/PromotionRepository.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/infrastructure/persistence/PromotionRepository.java
@@ -1,9 +1,14 @@
 package org.nextme.promotion_service.promotion.infrastructure.persistence;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.domain.PromotionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PromotionRepository extends JpaRepository<Promotion, UUID> {
+
+	// 특정 상태의 프로모션 조회
+	List<Promotion> findByStatus(PromotionStatus status);
 }

--- a/src/main/java/org/nextme/promotion_service/promotion/infrastructure/persistence/PromotionRepository.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/infrastructure/persistence/PromotionRepository.java
@@ -1,0 +1,9 @@
+package org.nextme.promotion_service.promotion.infrastructure.persistence;
+
+import java.util.UUID;
+
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PromotionRepository extends JpaRepository<Promotion, UUID> {
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/PromotionQueueService.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/PromotionQueueService.java
@@ -90,4 +90,15 @@ public class PromotionQueueService {
 		}
 		return Long.parseLong(value.toString());
 	}
+
+	/*
+	총 참여자 수 조회
+	@param promotionId 프로모션 ID
+	@return 총 참여자 수 (joined set 크기)
+	 */
+	public Long getParticipantCount(UUID promotionId) {
+		String joinedKey = RedisKeyGenerator.joinedKey(promotionId);
+		Long count = redisTemplate.opsForSet().size(joinedKey);
+		return count != null ? count : 0L;
+	}
 }

--- a/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/PromotionQueueService.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/PromotionQueueService.java
@@ -1,0 +1,93 @@
+package org.nextme.promotion_service.promotion.infrastructure.redis;
+
+import java.util.UUID;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionQueueService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	/*
+	대기열 등록
+	@param promotionId 프로모션 ID
+	@param data 저장할 데이터 (예 : "userId:ip:timestamp")
+	 */
+	public void enqueue(UUID promotionId, String data) {
+		String queueKey = RedisKeyGenerator.queueKey(promotionId);
+		redisTemplate.opsForList().rightPush(queueKey, data);
+	}
+
+	/*
+	대기열에서 데이터 꺼내기 (워커용)
+	@param promotionId 프로모션 ID
+	@return 대기열 맨 앞 데이터, 없으면 null
+	 */
+	public String dequeue(UUID promotionId) {
+		String queueKey = RedisKeyGenerator.queueKey(promotionId);
+		Object value = redisTemplate.opsForList().leftPop(queueKey);
+		return value != null ? value.toString() : null;
+	}
+
+	/*
+	중복 참여 체크 및 기록
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	@return true : 신규 참여, false : 중복 참여
+	 */
+	public boolean addToJoinedSet(UUID promotionId, Long userId) {
+		String joinedKey = RedisKeyGenerator.joinedKey(promotionId);
+		Long result = redisTemplate.opsForSet().add(joinedKey, userId);
+		return result != null && result == 1;
+	}
+
+	/*
+	참여 기록에서 제거 (롤백용)
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	 */
+	public void removeFromJoinedSet(UUID promotionId, Long userId) {
+		String joinedKey = RedisKeyGenerator.joinedKey(promotionId);
+		redisTemplate.opsForSet().remove(joinedKey, userId);
+	}
+
+	/*
+	대기열 크기 조회
+	@param promotionId 프로모션 ID
+	@param userId 사용자 ID
+	 */
+	public Long getQueueSize(UUID promotionId) {
+		String queueKey = RedisKeyGenerator.queueKey(promotionId);
+		Long size = redisTemplate.opsForList().size(queueKey);
+		return size != null ? size : 0L;
+	}
+
+	/*
+	당첨자 수 증가 (원자적)
+	@param promotionId 프로모션 ID
+	@return 증가 후 당첨자 수
+	 */
+	public Long incrementWinnerCount(UUID promotionId) {
+		String stockKey = RedisKeyGenerator.stockKey(promotionId);
+		return redisTemplate.opsForValue().increment(stockKey);
+	}
+
+	/*
+	현재 당첨자 수 조회
+	@param promotionId 프로모션 ID
+	@return 현재 당첨자 수
+	 */
+	public Long getWinnerCount(UUID promotionId) {
+		String stockKey = RedisKeyGenerator.stockKey(promotionId);
+		Object value = redisTemplate.opsForValue().get(stockKey);
+		if (value == null) {
+			return 0L;
+		}
+		return Long.parseLong(value.toString());
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/RedisKeyGenerator.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/infrastructure/redis/RedisKeyGenerator.java
@@ -1,0 +1,36 @@
+package org.nextme.promotion_service.promotion.infrastructure.redis;
+
+import java.util.UUID;
+
+/*
+Redis Key 생성 유틸리티
+프로모션 관련 Redis Key를 일관되게 생성
+ */
+public class RedisKeyGenerator {
+
+	private static final String PREFIX = "promotion:";
+
+	/*
+	대기열 Key 생성
+	promotion:{promotionId}:queue
+	 */
+	public static String queueKey(UUID promotionId) {
+		return PREFIX + promotionId + ":queue";
+	}
+
+	/*
+	참여 기록 Set Key 생성 (중복 방지용)
+	promotion:{promotionId}:joined
+	 */
+	public static String joinedKey(UUID promotionId) {
+		return PREFIX + promotionId + ":joined";
+	}
+
+	/*
+	당첨자 카운트 Key 생성
+	promotion:{promotionId}:stock
+	 */
+	public static String stockKey(UUID promotionId) {
+		return PREFIX + promotionId + ":stock";
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/PromotionController.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/PromotionController.java
@@ -1,0 +1,45 @@
+package org.nextme.promotion_service.promotion.presentation;
+
+import java.util.UUID;
+
+import org.nextme.infrastructure.success.CustomResponse;
+import org.nextme.promotion_service.promotion.application.PromotionParticipationService;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionJoinRequest;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionJoinResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/promotions")
+@RequiredArgsConstructor
+public class PromotionController {
+
+	private final PromotionParticipationService participationService;
+
+	/*
+	프로모션 참여 API
+	@param promotionId 프로모션 ID
+	@param request 참여 요청
+	@param httpRequest HTTP 요청 (IP 추출용)
+	@return 참여 결과
+	 */
+	@PostMapping("/{promotionId}/join")
+	public ResponseEntity<CustomResponse<PromotionJoinResponse>> joinPromotion(
+		@PathVariable UUID promotionId,
+		@Valid @RequestBody PromotionJoinRequest request,
+		HttpServletRequest httpRequest
+	) {
+		PromotionJoinResponse response = participationService.joinPromotion(promotionId, request.userId(), httpRequest);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/PromotionController.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/PromotionController.java
@@ -4,9 +4,16 @@ import java.util.UUID;
 
 import org.nextme.infrastructure.success.CustomResponse;
 import org.nextme.promotion_service.promotion.application.PromotionParticipationService;
+import org.nextme.promotion_service.promotion.application.PromotionService;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionCreateRequest;
 import org.nextme.promotion_service.promotion.presentation.dto.PromotionJoinRequest;
 import org.nextme.promotion_service.promotion.presentation.dto.PromotionJoinResponse;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionResponse;
+import org.nextme.promotion_service.promotion.presentation.dto.PromotionStatusResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +31,73 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PromotionController {
 
+	private final PromotionService promotionService;
 	private final PromotionParticipationService participationService;
+
+	/*
+	프로모션 생성 API
+	@param request 프로모션 생성 요청
+	@return 생성된 프로모션 정보
+	 */
+	@PostMapping
+	public ResponseEntity<CustomResponse<PromotionResponse>> createPromotion(
+		@Valid @RequestBody PromotionCreateRequest request
+	) {
+		PromotionResponse response = promotionService.createPromotion(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(CustomResponse.onSuccess(response));
+	}
+
+	/*
+	프로모션 조회 API
+	@param promotionId 프로모션 ID
+	@return 프로모션 정보
+	 */
+	@GetMapping("/{promotionId}")
+	public ResponseEntity<CustomResponse<PromotionResponse>> getPromotion(
+		@PathVariable UUID promotionId
+	) {
+		PromotionResponse response = promotionService.getPromotion(promotionId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+
+	/*
+	프로모션 시작 API
+	@param promotionId 프로모션 ID
+	@return 시작된 프로모션 정보
+	 */
+	@PatchMapping("/{promotionId}/start")
+	public ResponseEntity<CustomResponse<PromotionResponse>> startPromotion(
+		@PathVariable UUID promotionId
+	) {
+		PromotionResponse response = promotionService.startPromotion(promotionId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+
+	/*
+	프로모션 종료 API
+	@param promotionId 프로모션 ID
+	@return 종료된 프로모션 정보
+	 */
+	@PatchMapping("/{promotionId}/end")
+	public ResponseEntity<CustomResponse<PromotionResponse>> endPromotion(
+		@PathVariable UUID promotionId
+	) {
+		PromotionResponse response = promotionService.endPromotion(promotionId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
+
+	/*
+	프로모션 참여 현황 조회 API
+	@param promotionId 프로모션 ID
+	@return 참여 현황 정보
+	 */
+	@GetMapping("/{promotionId}/status")
+	public ResponseEntity<CustomResponse<PromotionStatusResponse>> getPromotionStatus(
+		@PathVariable UUID promotionId
+	) {
+		PromotionStatusResponse response = promotionService.getPromotionStatus(promotionId);
+		return ResponseEntity.ok(CustomResponse.onSuccess(response));
+	}
 
 	/*
 	프로모션 참여 API

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionCreateRequest.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionCreateRequest.java
@@ -1,0 +1,28 @@
+package org.nextme.promotion_service.promotion.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+// 프로모션 생성 요청 DTO
+public record PromotionCreateRequest(
+	@NotBlank(message = "프로모션 이름은 필수입니다")
+	String name,
+
+	@NotNull(message = "시작 시간은 필수입니다")
+	LocalDateTime startTime,
+
+	@NotNull(message = "종료 시간은 필수입니다")
+	LocalDateTime endTime,
+
+	@NotNull(message = "총 재고는 필수입니다")
+	@Min(value = 1, message = "총 재고는 1 이상이어야 합니다")
+	Integer totalStock,
+
+	@NotNull(message = "포인트 금액은 필수입니다")
+	@Min(value = 0, message = "포인트 금액은 0 이상이어야 합니다")
+	Integer pointAmount
+) {
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionJoinRequest.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionJoinRequest.java
@@ -1,0 +1,10 @@
+package org.nextme.promotion_service.promotion.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+// 프로모션 참여 요청 DTO
+public record PromotionJoinRequest(
+	@NotNull(message = "사용자 ID는 필수입니다")
+	Long userId
+) {
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionJoinResponse.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionJoinResponse.java
@@ -1,0 +1,18 @@
+package org.nextme.promotion_service.promotion.presentation.dto;
+
+// 프로모션 참여 응답 DTO
+public record PromotionJoinResponse(
+	boolean success,	// 성공 여부
+	String message,		// 응답 메시지
+	Long queuePosition
+) {
+	// 성공 응답 생성
+	public static PromotionJoinResponse success(String message, Long queuePosition) {
+		return new PromotionJoinResponse(true, message, queuePosition);
+	}
+
+	// 실패 응답 생성
+	public static PromotionJoinResponse failure(String message) {
+		return new PromotionJoinResponse(false, message, null);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionResponse.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionResponse.java
@@ -1,0 +1,34 @@
+package org.nextme.promotion_service.promotion.presentation.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.nextme.promotion_service.promotion.domain.Promotion;
+import org.nextme.promotion_service.promotion.domain.PromotionStatus;
+
+// 프로모션 응답 DTO
+public record PromotionResponse(
+	UUID id,
+	String name,
+	LocalDateTime startTime,
+	LocalDateTime endTime,
+	Integer totalStock,
+	Integer pointAmount,
+	PromotionStatus status,
+	String etc,
+	LocalDateTime createdAt
+) {
+	public static PromotionResponse from(Promotion promotion) {
+		return new PromotionResponse(
+			promotion.getId(),
+			promotion.getName(),
+			promotion.getStartTime(),
+			promotion.getEndTime(),
+			promotion.getTotalStock(),
+			promotion.getPointAmount(),
+			promotion.getStatus(),
+			promotion.getEtc(),
+			promotion.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionStatusResponse.java
+++ b/src/main/java/org/nextme/promotion_service/promotion/presentation/dto/PromotionStatusResponse.java
@@ -1,0 +1,26 @@
+package org.nextme.promotion_service.promotion.presentation.dto;
+
+// 프로모션 참여 현황 응답 DTO
+public record PromotionStatusResponse(
+	Long queueSize,        // 현재 대기열 크기
+	Long participantCount, // 총 참여자 수 (joined set)
+	Long winnerCount,      // 현재 당첨자 수
+	Integer totalStock,    // 총 재고
+	Integer remainingStock // 남은 재고
+) {
+	public static PromotionStatusResponse of(
+		Long queueSize,
+		Long participantCount,
+		Long winnerCount,
+		Integer totalStock
+	) {
+		int remaining = Math.max(0, totalStock - (winnerCount != null ? winnerCount.intValue() : 0));
+		return new PromotionStatusResponse(
+			queueSize,
+			participantCount,
+			winnerCount,
+			totalStock,
+			remaining
+		);
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 
   data:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,3 +17,21 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+      base-path: /actuator
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    export:
+      prometheus:
+        enabled: true
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true


### PR DESCRIPTION
## 📝 요약 (Summary)
대규모 트래픽을 처리할 수 있는 선착순 프로모션 참여 시스템을 Redis 대기열 패턴과 비동기 워커로 구현했습니다.

## 🛠️ 작업 내용 (Details)


  - Redis 기반 FIFO 대기열로 대규모 동시 접속 처리
  - INCR 원자적 연산으로 정확한 선착순 당첨자 선정
  - SET을 활용한 중복 참여 방지
  - 비동기 워커 + 배치 처리로 DB 성능 최적화
  - Prometheus/Grafana 모니터링 연동

 ### Architecture

```
  API Request → Redis Queue → Worker (1초 간격) → DB Batch Insert
                ├─ SET (중복체크)
                ├─ LIST (FIFO)
                └─ INCR (당첨 카운터)
```
 
### Implementation

#### 1. Domain Model

  - Promotion: 프로모션 엔티티 (UUID, SCHEDULED/ACTIVE/ENDED 상태)
  - PromotionParticipation: 참여 기록 (WON/LOST, queue_position, IP/User-Agent)

#### 2. Redis Operations

  // 중복 체크 + 참여 기록
  SADD promotion:{id}:joined {userId}

  // 대기열 등록
  RPUSH promotion:{id}:queue "userId:ip:userAgent:timestamp"

  // 선착순 판정
  INCR promotion:{id}:stock

#### 3. Worker Process

  - @Scheduled(fixedRate = 1000) - 1초마다 실행
  - LPOP 100개 배치 처리
  - INCR ≤ totalStock → 당첨, > totalStock → 탈락
  - saveAll() 배치 DB 저장

#### 4. API Endpoint
```json
  POST /v1/promotions/{promotionId}/join

  Response:
  {
    "success": true,
    "message": "대기열에 진입했습니다.",
    "queuePosition": 1
  }
```
#### 5. Error Codes:
  - PROMOTION_NOT_FOUND: 존재하지 않는 프로모션
  - PROMOTION_ALREADY_JOINED: 중복 참여
  - PROMOTION_QUEUE_FULL: 대기열 초과 (totalStock × 5)


## 🔀 변경 유형 (Change Type)

<!-- 어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요. -->

- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)

## 🧪 테스트 방법 (Testing)
- POST /v1/promotions - 프로모션 생성
- GET /v1/promotions/{id} - 프로모션 조회
- PATCH /v1/promotions/{id}/start - 프로모션 시작
- PATCH /v1/promotions/{id}/end - 프로모션 종료
- GET /v1/promotions/{id}/status - 참여 현황 조회
- POST /v1/promotions/{id}/join - 프로모션 참여
- GET /v1/promotions/{promotionId}/participations/{userId} - 특정 사용자의 참여 결과 조회
- GET /v1/promotions/{promotionId}/winners - 당첨자 목록 조회


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로모션 생성·시작·종료·상태조회·참가(큐 등록 및 대기열 위치 반환) REST API 추가
  * 백그라운드 대기열 처리기 도입으로 당첨자 선발 및 결과 저장 자동화
  * 참여 조회·당첨자 목록 조회 API 추가

* **Configuration**
  * Actuator 및 Prometheus 지표 노출 활성화, 애플리케이션 태그 설정
  * JPA DDL 모드 create → update 변경
  * 스케줄링 및 JPA auditing 활성화

* **Infrastructure**
  * Redis 기반 큐 및 참여자 집합 통합, 직렬화 설정 추가
  * 요청 유효성 검사 및 글로벌 예외 처리(사용자 메시지) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->